### PR TITLE
refactor: Unify LandingPage layout with shared withLayout helper

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ function AppLayout() {
   const withLayout = (Component: React.ElementType) => (
     <div className="flex flex-col min-h-screen">
       <Header />
-      <main className="flex-1">
+      <main id="main-content" className="flex-1">
         <Suspense fallback={
           <div className="flex-1 flex items-center justify-center bg-dark-950/50">
             <LoadingSpinner />
@@ -47,7 +47,7 @@ function AppLayout() {
     <div className={`min-h-screen flex flex-col ${theme === 'dark' ? 'dark bg-dark-950' : 'bg-light-50'} text-gray-900 dark:text-gray-100 selection:bg-cyber-blue/30 font-sans transition-colors duration-300`}>
       <ErrorBoundary>
         <Routes>
-          <Route path="/" element={<LandingPage />} />
+          <Route path="/" element={withLayout(LandingPage)} />
           <Route path="/simulator" element={withLayout(SimulatorPage)} />
           <Route path="/pricing" element={withLayout(PricingPage)} />
           <Route path="/contact" element={withLayout(ContactPage)} />

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -6,8 +6,6 @@
 import { lazy, Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import { motion, useReducedMotion } from "framer-motion";
-import Header from '../components/common/Header';
-import Footer from '../components/common/Footer';
 import { useTheme } from '../context/ThemeContext';
 import { cn } from '../utils/cn';
 import { useIsMobile } from '../hooks/useIsMobile';
@@ -149,9 +147,7 @@ export const LandingPage: React.FC = () => {
             <div className="scanline" aria-hidden="true" />
 
             <div className="relative z-10 font-sans">
-                <Header />
-
-                <main id="main-content">
+                <div id="landing-hero-container">
                     {/* Hero Section */}
                     <div className="container mx-auto px-4 pt-24 pb-16 sm:pt-32 sm:pb-24 lg:pt-40 lg:pb-32">
                         <div className="text-center max-w-7xl mx-auto">
@@ -379,9 +375,7 @@ export const LandingPage: React.FC = () => {
                             </Link>
                         </motion.div>
                     </section>
-                </main>
-
-                <Footer />
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
This PR unifies the layout management across the application by integrating the Landing Page into the shared layout container provided by `withLayout()`.

### Key Changes:
- **`App.tsx`**: Wrapped `LandingPage` with `withLayout()` and added `id="main-content"` to the shared `<main>` element for improved accessibility (supporting "Skip to Content").
- **`LandingPage.tsx`**: Removed redundant manual `Header` and `Footer` imports/rendering. Replaced the inner `<main>` tag with a semantic `div` to maintain valid HTML while keeping all "Cyber" background visuals (particles, grid, floating blobs).

Tests passed and visual verification confirmed that backgrounds remain intact and there is no duplication of Header/Footer.

Closes #80