### PR TITLE
chore: move PricingPage and ContactPage to src/pages/

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,8 @@ import Footer from './components/common/Footer';
 // Lazy load pages for better performance
 const LandingPage = lazy(() => import('./pages/LandingPage'));
 const SimulatorPage = lazy(() => import('./pages/SimulatorPage'));
-const PricingPage = lazy(() => import('./components/pages/PricingPage').then(m => ({ default: m.PricingPage })));
-const ContactPage = lazy(() => import('./components/pages/ContactPage').then(m => ({ default: m.ContactPage })));
+const PricingPage = lazy(() => import('./pages/PricingPage').then(m => ({ default: m.PricingPage })));
+const ContactPage = lazy(() => import('./pages/ContactPage').then(m => ({ default: m.ContactPage })));
 const ErrorPage = lazy(() => import('./pages/ErrorPage'));
 const PhysicalPage = lazy(() => import('./pages/PhysicalPage'));
 const GenerationsPage = lazy(() => import('./pages/GenerationsPage'));

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { CyberButton } from '../ui/CyberButton';
-import { sendContactEmail } from '../../services/emailService';
-import { supabase } from '../../config/supabase';
-import { useAuth } from '../../context/AuthContext';
+import { CyberButton } from '../components/ui/CyberButton';
+import { sendContactEmail } from '../services/emailService';
+import { supabase } from '../config/supabase';
+import { useAuth } from '../context/AuthContext';
 
 export const ContactPage: React.FC = () => {
     const { user } = useAuth();

--- a/src/pages/PricingPage.tsx
+++ b/src/pages/PricingPage.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { CyberButton } from '../ui/CyberButton';
-import { BorderBeam } from '../ui/BorderBeam';
-import { PLANS, type PlanId } from '../../services/razorpayService';
-import { useAuth } from '../../context/AuthContext';
-import { cn } from '../../utils/cn';
+import { CyberButton } from '../components/ui/CyberButton';
+import { BorderBeam } from '../components/ui/BorderBeam';
+import { PLANS, type PlanId } from '../services/razorpayService';
+import { useAuth } from '../context/AuthContext';
+import { cn } from '../utils/cn';
 
 const PLAN_FEATURES: Record<PlanId, string[]> = {
     free: [


### PR DESCRIPTION
## Changes
- Moved `src/components/pages/PricingPage.tsx` to `src/pages/PricingPage.tsx`
- Moved `src/components/pages/ContactPage.tsx` to `src/pages/ContactPage.tsx`
- Updated imports in `App.tsx`
- Updated relative imports in both moved files to point to their correct locations
- Removed the empty `src/components/pages/` directory

Resolves #81