### PR TITLE
fix(bus-topology): improve phase timeline and frame segment label readability

### DIFF
--- a/src/components/can/BusTopology.tsx
+++ b/src/components/can/BusTopology.tsx
@@ -679,7 +679,7 @@ const TransmissionPanel: React.FC<{
                                             transition={{ duration: 0.15 }}
                                         />
                                     </motion.div>
-                                    <span className={`text-[5px] font-mono uppercase tracking-wider truncate w-full text-center ${isActive ? 'font-bold' : ''}`}
+                                    <span className={`text-[9px] font-mono uppercase tracking-wider truncate w-full text-center ${isActive ? 'font-bold' : ''}`}
                                         style={{ color: isActive ? phaseColor : isCompleted ? phaseColor + '80' : '#333' }}>
                                         {PHASE_INFO[phase].label}
                                     </span>
@@ -716,7 +716,7 @@ const TransmissionPanel: React.FC<{
                                         ))}
                                     </div>
                                 )}
-                                <span className="text-[6px] font-mono font-bold uppercase z-10 relative" style={{ color: isActive ? phaseColor : isCompleted ? phaseColor + '80' : '#555' }}>
+                                <span className="text-[8px] font-mono font-bold uppercase z-10 relative" style={{ color: isActive ? phaseColor : isCompleted ? phaseColor + '80' : '#555' }}>
                                     {phase === 'data' ? `${transmission.dlc}B` : PHASE_INFO[phase].label}
                                 </span>
                                 {/* ACK indicator */}


### PR DESCRIPTION
This PR improves the readability of the CAN frame phase timeline and frame segment labels in the `TransmissionPanel` of `BusTopology.tsx`.

### Changes:
- Promoted phase timeline labels from `text-[5px]` to `text-[9px]`.
- Promoted CAN frame visualization segment labels from `text-[6px]` to `text-[8px]`.

These changes ensure that the primary educational features of the transmission panel are actually readable on standard displays.

Build verified with `npm run build`.
Closes #52.